### PR TITLE
Don't recalculate transaction hash for external transactions.

### DIFF
--- a/tx_builder.go
+++ b/tx_builder.go
@@ -231,6 +231,10 @@ func (tb *TxBuilder) BuildWithoutValidation() (*Tx, error) {
 	return tb.tx, nil
 }
 
+func (tb *TxBuilder) SetWrappedTxBody(wrappedTxBody []byte) {
+	tb.tx.Body.WrappedTxBody = wrappedTxBody
+}
+
 // Build returns a new transaction using the inputs, outputs and keys provided.
 func (tb *TxBuilder) Build() (*Tx, error) {
 	inputAmount, outputAmount := tb.calculateAmounts()


### PR DESCRIPTION
If a transaction was generated externally then when getting the body hash this change just uses the given transaction without unmarshalling and remarshelling to avoid potential issues with changes to the CBOR representation of the transaction (e.g., order of keys).