### PR TITLE
This adds Plutus scripts and tags redeemers and collateral.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -105,7 +105,7 @@ type WitnessSet struct {
 	VKeyWitnessSet []VKeyWitness  `cbor:"0,keyasint,omitempty"`
 	Scripts        []NativeScript `cbor:"1,keyasint,omitempty"`
 	Redeemers      []Redeemer     `cbor:"5,keyasint,omitempty"`
-	PlutusScripts  cbor.Tag       `cbor:"7,keyasint,omitempty"`
+	PlutusScripts  *cbor.Tag      `cbor:"7,keyasint,omitempty"`
 }
 
 func (ws *WitnessSet) MarshalCBOR() ([]byte, error) {
@@ -113,7 +113,7 @@ func (ws *WitnessSet) MarshalCBOR() ([]byte, error) {
 		VKeyWitnessSet cbor.Tag       `cbor:"0,keyasint,omitempty"`
 		Scripts        []NativeScript `cbor:"1,keyasint,omitempty"`
 		RedeemerSet    []Redeemer     `cbor:"5,keyasint,omitempty"`
-		PlutusScripts  cbor.Tag       `cbor:"7,keyasint,omitempty"`
+		PlutusScripts  *cbor.Tag      `cbor:"7,keyasint,omitempty"`
 	}
 
 	tagged := taggedTx{
@@ -391,8 +391,8 @@ func (body *TxBody) MarshalCBOR() ([]byte, error) {
 		ValidityIntervalStart Uint64        `cbor:"8,keyasint,omitempty"`
 		Mint                  *Mint         `cbor:"9,keyasint,omitempty"`
 		ScriptDataHash        *Hash32       `cbor:"11,keyasint,omitempty"`
-		Collateral            cbor.Tag      `cbor:"13,keyasint,omitempty"`
-		RequiredSigners       cbor.Tag      `cbor:"14,keyasint,omitempty"`
+		Collateral            *cbor.Tag     `cbor:"13,keyasint,omitempty"`
+		RequiredSigners       *cbor.Tag     `cbor:"14,keyasint,omitempty"`
 		NetworkID             Uint64        `cbor:"15,keyasint,omitempty"`
 		CollateralReturn      *TxOutput     `cbor:"16,keyasint,omitempty"`
 		TotalCollateral       Coin          `cbor:"17,keyasint,omitempty"`
@@ -415,18 +415,24 @@ func (body *TxBody) MarshalCBOR() ([]byte, error) {
 		ValidityIntervalStart: body.ValidityIntervalStart,
 		Mint:                  body.Mint,
 		ScriptDataHash:        body.ScriptDataHash,
-		Collateral: cbor.Tag{
+		NetworkID:             body.NetworkID,
+		CollateralReturn:      body.CollateralReturn,
+		TotalCollateral:       body.TotalCollateral,
+		ReferenceInputs:       body.ReferenceInputs,
+	}
+
+	if len(body.Collateral) > 0 {
+		tagged.Collateral = &cbor.Tag{
 			Number:  258,
 			Content: body.Collateral,
-		},
-		RequiredSigners: cbor.Tag{
+		}
+	}
+
+	if len(body.RequiredSigners) > 0 {
+		tagged.RequiredSigners = &cbor.Tag{
 			Number:  258,
 			Content: body.RequiredSigners,
-		},
-		NetworkID:        body.NetworkID,
-		CollateralReturn: body.CollateralReturn,
-		TotalCollateral:  body.TotalCollateral,
-		ReferenceInputs:  body.ReferenceInputs,
+		}
 	}
 
 	return cborEnc.Marshal(tagged)

--- a/tx.go
+++ b/tx.go
@@ -71,10 +71,59 @@ func (tx *Tx) MarshalCBOR() ([]byte, error) {
 	return cborEnc.Marshal(rawTx(*tx))
 }
 
+type Redeemer struct {
+	_              struct{} `cbor:",toarray"`
+	Tag            uint64
+	Index          uint64
+	Data           []byte
+	ExecutionUnits []uint64
+}
+
+func (r *Redeemer) MarshalCBOR() ([]byte, error) {
+	type taggedRedeemer struct {
+		_              struct{} `cbor:",toarray"`
+		Tag            uint64
+		Index          uint64
+		Data           cbor.Tag
+		ExecutionUnits []uint64
+	}
+
+	tagged := taggedRedeemer{
+		Tag:   r.Tag,
+		Index: r.Index,
+		Data: cbor.Tag{Number: 121, Content: struct {
+			_ struct{} `cbor:",toarray"`
+		}{}},
+		ExecutionUnits: r.ExecutionUnits,
+	}
+
+	return cborEnc.Marshal(tagged)
+}
+
 // WitnessSet represents the witnesses of the transaction.
 type WitnessSet struct {
 	VKeyWitnessSet []VKeyWitness  `cbor:"0,keyasint,omitempty"`
 	Scripts        []NativeScript `cbor:"1,keyasint,omitempty"`
+	Redeemers      []Redeemer     `cbor:"5,keyasint,omitempty"`
+	PlutusScripts  cbor.Tag       `cbor:"7,keyasint,omitempty"`
+}
+
+func (ws *WitnessSet) MarshalCBOR() ([]byte, error) {
+	type taggedTx struct {
+		VKeyWitnessSet cbor.Tag       `cbor:"0,keyasint,omitempty"`
+		Scripts        []NativeScript `cbor:"1,keyasint,omitempty"`
+		RedeemerSet    []Redeemer     `cbor:"5,keyasint,omitempty"`
+		PlutusScripts  cbor.Tag       `cbor:"7,keyasint,omitempty"`
+	}
+
+	tagged := taggedTx{
+		VKeyWitnessSet: cbor.Tag{Number: 258, Content: ws.VKeyWitnessSet},
+		Scripts:        ws.Scripts,
+		RedeemerSet:    ws.Redeemers,
+		PlutusScripts:  ws.PlutusScripts,
+	}
+
+	return cborEnc.Marshal(tagged)
 }
 
 // VKeyWitness is a witnesss that uses verification keys.
@@ -141,6 +190,24 @@ func (do *DatumOption) String() string {
 	default:
 		return fmt.Sprintf("%v", *do)
 	}
+}
+
+func (body *DatumOption) MarshalCBOR() ([]byte, error) {
+	type taggedDatumOption struct {
+		_    struct{} `cbor:",toarray"`
+		Type DatumType
+		Data cbor.Tag
+	}
+
+	tagged := taggedDatumOption{
+		Type: DatumTypeData,
+		Data: cbor.Tag{
+			Number:  24,
+			Content: body.Data,
+		},
+	}
+
+	return cborEnc.Marshal(tagged)
 }
 
 // TxLegacyOutput is the transaction output before alonzo, shelley-mary-allegra.
@@ -324,8 +391,8 @@ func (body *TxBody) MarshalCBOR() ([]byte, error) {
 		ValidityIntervalStart Uint64        `cbor:"8,keyasint,omitempty"`
 		Mint                  *Mint         `cbor:"9,keyasint,omitempty"`
 		ScriptDataHash        *Hash32       `cbor:"11,keyasint,omitempty"`
-		Collateral            []*TxInput    `cbor:"13,keyasint,omitempty"`
-		RequiredSigners       []AddrKeyHash `cbor:"14,keyasint,omitempty"`
+		Collateral            cbor.Tag      `cbor:"13,keyasint,omitempty"`
+		RequiredSigners       cbor.Tag      `cbor:"14,keyasint,omitempty"`
 		NetworkID             Uint64        `cbor:"15,keyasint,omitempty"`
 		CollateralReturn      *TxOutput     `cbor:"16,keyasint,omitempty"`
 		TotalCollateral       Coin          `cbor:"17,keyasint,omitempty"`
@@ -348,12 +415,18 @@ func (body *TxBody) MarshalCBOR() ([]byte, error) {
 		ValidityIntervalStart: body.ValidityIntervalStart,
 		Mint:                  body.Mint,
 		ScriptDataHash:        body.ScriptDataHash,
-		Collateral:            body.Collateral,
-		RequiredSigners:       body.RequiredSigners,
-		NetworkID:             body.NetworkID,
-		CollateralReturn:      body.CollateralReturn,
-		TotalCollateral:       body.TotalCollateral,
-		ReferenceInputs:       body.ReferenceInputs,
+		Collateral: cbor.Tag{
+			Number:  258,
+			Content: body.Collateral,
+		},
+		RequiredSigners: cbor.Tag{
+			Number:  258,
+			Content: body.RequiredSigners,
+		},
+		NetworkID:        body.NetworkID,
+		CollateralReturn: body.CollateralReturn,
+		TotalCollateral:  body.TotalCollateral,
+		ReferenceInputs:  body.ReferenceInputs,
 	}
 
 	return cborEnc.Marshal(tagged)

--- a/tx.go
+++ b/tx.go
@@ -3,6 +3,7 @@ package cardano
 import (
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	cborv2 "github.com/fxamacker/cbor/v2"
 	"github.com/melraidin/cardano-go/crypto"
@@ -79,21 +80,51 @@ type Redeemer struct {
 	ExecutionUnits []uint64
 }
 
-func (r *Redeemer) MarshalCBOR() ([]byte, error) {
-	type taggedRedeemer struct {
+func (r *Redeemer) UnmarshalCBOR(data []byte) error {
+	type rawRedeemer struct {
 		_              struct{} `cbor:",toarray"`
 		Tag            uint64
 		Index          uint64
-		Data           cbor.Tag
+		Data           cbor.RawMessage
 		ExecutionUnits []uint64
 	}
 
-	tagged := taggedRedeemer{
-		Tag:   r.Tag,
-		Index: r.Index,
-		Data: cbor.Tag{Number: 121, Content: struct {
+	var rr rawRedeemer
+	if err := cborDec.Unmarshal(data, &rr); err != nil {
+		return err
+	}
+
+	r.Tag = rr.Tag
+	r.Index = rr.Index
+	r.Data = append(r.Data[:0], rr.Data...)
+	r.ExecutionUnits = append(r.ExecutionUnits[:0], rr.ExecutionUnits...)
+	return nil
+}
+
+func (r *Redeemer) MarshalCBOR() ([]byte, error) {
+	type rawRedeemer struct {
+		_              struct{} `cbor:",toarray"`
+		Tag            uint64
+		Index          uint64
+		Data           cbor.RawMessage
+		ExecutionUnits []uint64
+	}
+
+	redeemerData := cbor.RawMessage(r.Data)
+	if len(redeemerData) == 0 {
+		emptyData, err := cborEnc.Marshal(cbor.Tag{Number: 121, Content: struct {
 			_ struct{} `cbor:",toarray"`
-		}{}},
+		}{}})
+		if err != nil {
+			return nil, err
+		}
+		redeemerData = emptyData
+	}
+
+	tagged := rawRedeemer{
+		Tag:            r.Tag,
+		Index:          r.Index,
+		Data:           redeemerData,
 		ExecutionUnits: r.ExecutionUnits,
 	}
 
@@ -106,6 +137,96 @@ type WitnessSet struct {
 	Scripts        []NativeScript `cbor:"1,keyasint,omitempty"`
 	Redeemers      []Redeemer     `cbor:"5,keyasint,omitempty"`
 	PlutusScripts  *cbor.Tag      `cbor:"7,keyasint,omitempty"`
+}
+
+func (ws *WitnessSet) UnmarshalCBOR(data []byte) error {
+	rawFields := map[uint64]cbor.RawMessage{}
+	if err := cborDec.Unmarshal(data, &rawFields); err != nil {
+		return err
+	}
+
+	if field, ok := rawFields[0]; ok {
+		if err := cborDec.Unmarshal(field, &ws.VKeyWitnessSet); err != nil {
+			return err
+		}
+	}
+
+	if field, ok := rawFields[1]; ok {
+		if err := cborDec.Unmarshal(field, &ws.Scripts); err != nil {
+			return err
+		}
+	}
+
+	if field, ok := rawFields[5]; ok {
+		redeemers, err := unmarshalRedeemers(field)
+		if err != nil {
+			return err
+		}
+		ws.Redeemers = redeemers
+	}
+
+	if field, ok := rawFields[7]; ok {
+		var plutusScripts cbor.Tag
+		if err := cborDec.Unmarshal(field, &plutusScripts); err != nil {
+			return err
+		}
+		ws.PlutusScripts = &plutusScripts
+	}
+
+	return nil
+}
+
+func unmarshalRedeemers(data []byte) ([]Redeemer, error) {
+	type redeemerPointer struct {
+		_     struct{} `cbor:",toarray"`
+		Tag   uint64
+		Index uint64
+	}
+
+	type redeemerValue struct {
+		_              struct{} `cbor:",toarray"`
+		Data           cbor.RawMessage
+		ExecutionUnits []uint64
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	switch data[0] & 0xe0 {
+	case 0x80:
+		var redeemers []Redeemer
+		if err := cborDec.Unmarshal(data, &redeemers); err != nil {
+			return nil, err
+		}
+		return redeemers, nil
+	case 0xa0:
+		var redeemerMap map[redeemerPointer]redeemerValue
+		if err := cborDec.Unmarshal(data, &redeemerMap); err != nil {
+			return nil, err
+		}
+
+		redeemers := make([]Redeemer, 0, len(redeemerMap))
+		for ptr, value := range redeemerMap {
+			redeemers = append(redeemers, Redeemer{
+				Tag:            ptr.Tag,
+				Index:          ptr.Index,
+				Data:           append([]byte(nil), value.Data...),
+				ExecutionUnits: append([]uint64(nil), value.ExecutionUnits...),
+			})
+		}
+
+		sort.Slice(redeemers, func(i, j int) bool {
+			if redeemers[i].Tag != redeemers[j].Tag {
+				return redeemers[i].Tag < redeemers[j].Tag
+			}
+			return redeemers[i].Index < redeemers[j].Index
+		})
+
+		return redeemers, nil
+	default:
+		return nil, fmt.Errorf("unsupported redeemer set type: 0x%x", data[0])
+	}
 }
 
 func (ws *WitnessSet) MarshalCBOR() ([]byte, error) {
@@ -373,6 +494,18 @@ type TxBody struct {
 	CollateralReturn      *TxOutput     `cbor:"16,keyasint,omitempty"`
 	TotalCollateral       Coin          `cbor:"17,keyasint,omitempty"`
 	ReferenceInputs       []*TxInput    `cbor:"18,keyasint,omitempty"`
+}
+
+func (body *TxBody) UnmarshalCBOR(data []byte) error {
+	type rawTxBody TxBody
+	var rtb rawTxBody
+
+	if err := cborDec.Unmarshal(data, &rtb); err != nil {
+		return err
+	}
+
+	*body = TxBody(rtb)
+	return nil
 }
 
 // MarshalCBOR implements cbor.Marshaler for TxBody.

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -88,7 +88,7 @@ func (tb *TxBuilder) AddNativeScript(script NativeScript) {
 
 // AddPlutusScript adds a plutus script to the transaction.
 func (tb *TxBuilder) AddPlutusScript(script []byte) {
-	tb.tx.WitnessSet.PlutusScripts = cbor.Tag{
+	tb.tx.WitnessSet.PlutusScripts = &cbor.Tag{
 		Number:  258,
 		Content: []any{script},
 	}

--- a/tx_builder.go
+++ b/tx_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/melraidin/cardano-go/crypto"
+	"github.com/melraidin/cardano-go/internal/cbor"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -83,6 +84,18 @@ func (tb *TxBuilder) AddCertificate(cert Certificate) {
 // AddNativeScript adds a native script to the transaction.
 func (tb *TxBuilder) AddNativeScript(script NativeScript) {
 	tb.tx.WitnessSet.Scripts = append(tb.tx.WitnessSet.Scripts, script)
+}
+
+// AddPlutusScript adds a plutus script to the transaction.
+func (tb *TxBuilder) AddPlutusScript(script []byte) {
+	tb.tx.WitnessSet.PlutusScripts = cbor.Tag{
+		Number:  258,
+		Content: []any{script},
+	}
+}
+
+func (tb *TxBuilder) AddRedeemer(redeemer Redeemer) {
+	tb.tx.WitnessSet.Redeemers = append(tb.tx.WitnessSet.Redeemers, redeemer)
 }
 
 // Mint adds a new multiasset to mint.
@@ -337,7 +350,6 @@ func (tb *TxBuilder) build() error {
 		return err
 	}
 
-	//fmt.Println("unsign tx: ", hex.EncodeToString(tb.tx.Bytes()))
 	// Create witness set
 	tb.tx.WitnessSet.VKeyWitnessSet = make([]VKeyWitness, len(tb.pkeys))
 	for i, pkey := range tb.pkeys {

--- a/tx_test.go
+++ b/tx_test.go
@@ -91,6 +91,32 @@ func TestTxEncoding(t *testing.T) {
 	}
 }
 
+func TestRedeemerMarshalCBOREmptyDataUsesTaggedEmptyArray(t *testing.T) {
+	redeemer := Redeemer{
+		Tag:            0,
+		Index:          1,
+		ExecutionUnits: []uint64{2, 3},
+	}
+
+	data, err := redeemer.MarshalCBOR()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded []cbor.RawMessage
+	if err := cbor.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(decoded) != 4 {
+		t.Fatalf("expected 4 redeemer fields, got %d", len(decoded))
+	}
+
+	if got := hex.EncodeToString(decoded[2]); got != "d87980" {
+		t.Fatalf("expected empty redeemer data to encode as tag 121 empty array, got %s", got)
+	}
+}
+
 func TestCertificateEncoding(t *testing.T) {
 	testcases := []struct {
 		name    string


### PR DESCRIPTION
This adds Plutus scripts and tags redeemers and collateral.

Previously there was no support for adding a Plutus script to a
transaction. This now is available. As well redeemers and collateral
are tagged to match cardano-cli's output.